### PR TITLE
feat: add default mainnet config values

### DIFF
--- a/.changelog/unreleased/feature/3-mainnet-config.md
+++ b/.changelog/unreleased/feature/3-mainnet-config.md
@@ -1,0 +1,1 @@
+- Add default mainnet config values. ([#3](https://github.com/noble-assets/jester/pull/3))

--- a/ethereum/chain.go
+++ b/ethereum/chain.go
@@ -121,10 +121,11 @@ func newConfig(log *slog.Logger, websocketurl, rpcurl string, testnet bool, over
 		c.WormholeTransceiver = "0x0763196A091575adF99e2306E5e90E0Be5154841"
 	default:
 		c.WormholeSrcChainId = 2
-		c.WormholeApiUrl = ""      // TODO
-		c.HubPortal = ""           // TODO
-		c.WormholeCore = ""        // TODO
-		c.WormholeTransceiver = "" // TODO
+		c.WormholeApiUrl = "https://api.wormholescan.io/v1/signed_vaa"
+		c.HubPortal = "0x83Ae82Bd4054e815fB7B189C39D9CE670369ea16"
+		// https://wormhole.com/docs/build/reference/contract-addresses/#__tabbed_1_1
+		c.WormholeCore = "0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B"
+		c.WormholeTransceiver = "0xc7Dd372c39E38BF11451ab4A8427B4Ae38ceF644"
 	}
 
 	// Overrides


### PR DESCRIPTION
This PR adds the default mainnet configuration. It is currently marked as a draft until M^0 provides us with our Wormhole Transceiver contract.

- The `HubPortal` contract can be retrieved from our governance proposal [here](https://governance.m0.org/proposal/4667107318481624937727156994524820506681083579278923402903765261856732453818).
- The `WormholeCore` contract can be retrieved from Wormhole's documentation [here](https://wormhole.com/docs/build/reference/contract-addresses/#__tabbed_1_1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added default mainnet configuration values, enhancing the Ethereum instance setup for non-testnet environments.
  
- **Bug Fixes**
  - Replaced temporary placeholder settings with validated production endpoints and contract addresses in the Ethereum configuration, improving connectivity and reliability for live Ethereum operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->