### PR TITLE
chore(api): downgrade go to `v1.22`

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,13 +1,8 @@
 module jester.noble.xyz/api
 
-go 1.24
+go 1.22.11
 
 require (
 	connectrpc.com/connect v1.18.1
 	google.golang.org/protobuf v1.36.5
-)
-
-require (
-	github.com/google/go-cmp v0.6.0 // indirect
-	golang.org/x/net v0.35.0 // indirect
 )

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module jester.noble.xyz/api
 
-go 1.22.11
+go 1.22
 
 require (
 	connectrpc.com/connect v1.18.1

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,10 +1,10 @@
 connectrpc.com/connect v1.18.1 h1:PAg7CjSAGvscaf6YZKUefjoih5Z/qYkyaTrBW8xvYPw=
 connectrpc.com/connect v1.18.1/go.mod h1:0292hj1rnx8oFrStN7cB4jjVBeqs+Yx5yDIC2prWDO8=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
-golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
-golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
-golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
+golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
 google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=

--- a/go.work
+++ b/go.work
@@ -1,6 +1,5 @@
 go 1.24
 
-use (
-	.
-	api
-)
+use .
+
+replace jester.noble.xyz/api v1.0.0 => ./api

--- a/go.work
+++ b/go.work
@@ -1,5 +1,0 @@
-go 1.24
-
-use .
-
-replace jester.noble.xyz/api v1.0.0 => ./api


### PR DESCRIPTION
To maintain compatibility with the Noble binary, we must keep the API in line with Nobles Golang version. 
Otherwise, Jester will force Noble to update Go, which for now, would like to avoid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the underlying runtime to a more stable version.
	- Removed unused dependency configurations to streamline the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->