### PR TITLE
fix: blockNumber in `debug` log

### DIFF
--- a/.changelog/unreleased/Bug Fixes/14-blockNumber-in-log.md
+++ b/.changelog/unreleased/Bug Fixes/14-blockNumber-in-log.md
@@ -1,1 +1,1 @@
-- fixes the `blockNumber` reported a debug log ([#14](https://github.com/noble-assets/jester/pull/14))
+- correctly log `blockNumber` in debug logs ([#14](https://github.com/noble-assets/jester/pull/14))

--- a/.changelog/unreleased/Bug Fixes/14-blockNumber-in-log.md
+++ b/.changelog/unreleased/Bug Fixes/14-blockNumber-in-log.md
@@ -1,0 +1,1 @@
+- fixes the `blockNumber` reported a debug log ([#14](https://github.com/noble-assets/jester/pull/14))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+
+### BUG FIXES
+
+- fixes the `blockNumber` reported a debug log ([#14](https://github.com/noble-assets/jester/pull/14))
+
 ## v1.0.0
 
 *Mar 3, 2025*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # CHANGELOG
 
-## Unreleased
-
-### BUG FIXES
-
-- fixes the `blockNumber` reported a debug log ([#14](https://github.com/noble-assets/jester/pull/14))
-
 ## v1.0.0
 
 *Mar 3, 2025*

--- a/ethereum/history.go
+++ b/ethereum/history.go
@@ -129,7 +129,7 @@ func (e *Eth) GetHistory(
 				if err := wormholeAbi.UnpackIntoInterface(&event, "LogMessagePublished", lLog.Data); err != nil {
 					log.Error("error unpacking wormhole abi into interface when querying history", "error", err)
 				}
-				log.Debug("found relevant events during historical query", "block", event.Raw.BlockNumber, "seq", event.Sequence)
+				log.Debug("found relevant events during historical query", "block", lLog.BlockNumber, "seq", event.Sequence)
 				processingQueue <- &utils.QueryData{
 					Sequence: event.Sequence,
 					TxHash:   txHash.String(),


### PR DESCRIPTION
`UnpackIntoInterface` does not unpack the `Raw` Ethereum log. This is where we were originally getting the `BlockNumber`. When testing, everything in `Raw` was zeroed out.

Instead, lets get to the block number before using `UnpackIntoInterface`.

This is a minor bug fix and does not need to be immediately implemented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced logging accuracy: The system now reports the correct block number during debugging, ensuring more reliable tracking of events and improved troubleshooting capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->