### PR TITLE
fix: Safely Increment Metrics when Querying VAA's.

### DIFF
--- a/.changelog/unreleased/fix/22-properly-inc-metrics.md
+++ b/.changelog/unreleased/fix/22-properly-inc-metrics.md
@@ -1,0 +1,1 @@
+- Fixes an issues where Jester could crash if the user disables the metrics server. ([#22](https://github.com/noble-assets/jester/pull/22))

--- a/wormhole/wormholeAPIQuery.go
+++ b/wormhole/wormholeAPIQuery.go
@@ -157,9 +157,9 @@ func (w *Wormhole) fetchVaa(
 	if err != nil {
 		if currentAttempt == w.config.fetchVAAAttempts-1 {
 			err = fmt.Errorf("max VAA lookup attempts reached: %w", err)
-			m.VAAFailedMaxAttemptsReached.Inc()
+			m.IncVAAFailedMaxAttemptsReached()
 		}
-		m.VAAFailedTotal.Inc()
+		m.IncVAAFailedTotal()
 		return WormholeResp{}, fmt.Errorf("query URL: %s: %w", url, err)
 	}
 
@@ -169,6 +169,6 @@ func (w *Wormhole) fetchVaa(
 		m.VAAReceiveDuration.Observe(float64(elapsed.Minutes()))
 	}
 
-	m.VAAFoundTotal.Inc()
+	m.IncVAAFoundTotal()
 	return wormholeResp, nil
 }


### PR DESCRIPTION
This PR addresses an issue where Jester could crash if the user disables the metrics server.