### PR TITLE
fix: update request timeout

### DIFF
--- a/.changelog/unreleased/fix/25-wormhole-request.md
+++ b/.changelog/unreleased/fix/25-wormhole-request.md
@@ -1,0 +1,1 @@
+- Add context to network request and catch all timeouts in retry logic.([#25](https://github.com/noble-assets/jester/pull/25))

--- a/utils/wormholeQuery.go
+++ b/utils/wormholeQuery.go
@@ -149,7 +149,7 @@ func fetchVaa(
 				return true
 			}
 
-			// saftey net to catch and retry in the case of any other network timouts
+			// safety net to catch and retry in the case of any other network timeouts
 			var netErr net.Error
 			if errors.As(err, &netErr) && netErr.Timeout() {
 				return true

--- a/utils/wormholeQuery.go
+++ b/utils/wormholeQuery.go
@@ -99,17 +99,15 @@ func fetchVaa(
 
 	err := retry.Do(
 		func() error {
-			req, err := http.NewRequest("GET", url, nil)
+			reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
+
+			req, err := http.NewRequestWithContext(reqCtx, "GET", url, nil)
 			if err != nil {
 				return fmt.Errorf("failed to create request: %w", err)
 			}
 
 			req.Header.Set("accept", "application/json")
-
-			reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-			defer cancel()
-
-			req = req.WithContext(reqCtx)
 
 			client := &http.Client{}
 			resp, err := client.Do(req)


### PR DESCRIPTION
This PR updates the way we handle http request timeouts.
Turns out adding the timeout field to the http client has been depreciated. 
Instead, we should add the timeout to the request in the form of a context.

This PR also adds extra error handling in the retry function to ensure we catch all forms of network timeouts.

--- 
For context, prior to this PR, this error would exit the retry loop:
```log
Get "https://api.wormholescan.io/v1/signed_vaa/2/000000000000000000000000c7dd372c39e38bf11451ab4a8427b4ae38cef644/658": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of network requests by enhancing timeout handling and expanding retry conditions to cover more network errors and timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->