### PR TITLE
fix: safely adjust metrics

### DIFF
--- a/.changelog/unreleased/fix/26-properly-adjust-metrics.md
+++ b/.changelog/unreleased/fix/26-properly-adjust-metrics.md
@@ -1,1 +1,1 @@
-- Fixes an issues where Jester could crash if the user disables the metrics server. ([#26](https://github.com/noble-assets/jester/pull/26))
+- Fixes an issue where Jester could crash if the user disables the metrics server. ([#26](https://github.com/noble-assets/jester/pull/26))

--- a/.changelog/unreleased/fix/26-properly-adjust-metrics.md
+++ b/.changelog/unreleased/fix/26-properly-adjust-metrics.md
@@ -1,0 +1,1 @@
+- Fixes an issues where Jester could crash if the user disables the metrics server. ([#26](https://github.com/noble-assets/jester/pull/26))

--- a/utils/wormholeQuery.go
+++ b/utils/wormholeQuery.go
@@ -165,9 +165,9 @@ func fetchVaa(
 	if err != nil {
 		if currentAttempt == fetchVAAAttempts-1 {
 			err = fmt.Errorf("max VAA lookup attempts reached: %w", err)
-			m.VAAFailedMaxAttemptsReached.Inc()
+			m.IncVAAFailedMaxAttemptsReached()
 		}
-		m.VAAFailedTotal.Inc()
+		m.IncVAAFailedTotal()
 		return WormholeResp{}, fmt.Errorf("query URL: %s: %w", url, err)
 	}
 
@@ -177,6 +177,6 @@ func fetchVaa(
 		m.VAAReceiveDuration.Observe(float64(elapsed.Minutes()))
 	}
 
-	m.VAAFoundTotal.Inc()
+	m.IncVAAFoundTotal()
 	return wormholeResp, nil
 }


### PR DESCRIPTION
This PR addresses an issue where Jester could crash if the user has disabled the metrics server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a changelog entry describing a fix for a crash that occurred when disabling the metrics server.

- **Refactor**
  - Updated the way metrics are incremented to use dedicated methods instead of direct field access. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->